### PR TITLE
Move to RTIC and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,17 @@ version = "0.1.0"
 
 [dependencies]
 cortex-m = "0.6.0"
-cortex-m-rt = "0.6.11"
-cortex-m-rtfm = { version= "0.5.1"}
-cortex-m-semihosting = "0.3.3"
+cortex-m-rt = "0.6.13"
+cortex-m-rtic = { version= "0.5.5"}
+cortex-m-semihosting = "0.3.5"
 panic-halt = "0.2.0"
-panic-semihosting = "*"
+panic-semihosting = "0.5.4"
 usb-device = {version = "0.2.3"}  
-stm32f1xx-hal = {version="0.5.2", features = ["rt","stm32f103","stm32-usbd"]}   
-stm32-usbd = { version = "0.5.0", features = ["ram_access_1x16"] }
+stm32f1xx-hal = {version="0.7.0", features = ["rt", "stm32f103", "stm32-usbd"]}   
+stm32-usbd = { version = "0.5.1", features = ["ram_access_1x16"] }
 usbd-midi = { version= "0.2.0" }
-embedded-hal = "0.2.3"
-heapless = "0.5.2"
+embedded-hal = "0.2.4"
+heapless = "0.5.6"
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use usbd_midi::{
     midi_device::MidiClass,
 };
 
-#[rtfm::app(device = stm32f1xx_hal::stm32,
+#[rtic::app(device = stm32f1xx_hal::stm32,
             peripherals = true)]
 const APP: () = {
     struct Resources {


### PR DESCRIPTION
Hi

Cool project!

I have updated your repo to RTIC v5, and changed up the dependencies. As I don't have a "stomp" box, I cannot test that it actually stomps as intended :) It compiles, that is the only thing I checked.

So please try it before accepting the PR.

I would be happy to discuss further capabilities of the `usbd-midi` implementation. A while back I implemented a midi-fader (used for scratching) in Rust (and just the bare necessity to get midi working). I experienced some compatibility problems, it worked in Linux and Windows, but not under OSX. Comparing the behavior of USB communication using Wire shark, and found that OSX is actually assuming even an input device to accept outgoing packages. With this implemented on the target side (actually just ignoring the data) I got it working also under OSX. I used a bluepill as well by the way.

Best regards.
  Per